### PR TITLE
Add maven_install.use_unsafe_shared_cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,32 @@ android_library(
 
 ## Advanced usage
 
+### Using a persistent artifact cache
+
+To download artifacts into a shared and persistent directory in your home
+directory, specify `use_unsafe_shared_cache = True` in `maven_install`:
+
+```python
+maven_install(
+    name = "maven",
+    artifacts = [
+        # ...
+    ],
+    repositories = [
+        # ...
+    ],
+    use_unsafe_shared_cache = True,
+)
+```
+
+This is **not safe** as Bazel is currently not able to detect changes in the
+shared cache. For example, if an artifact is deleted from the shared cache,
+Bazel will not re-run the repository rule automatically.
+
+The default value of `use_unsafe_shared_cache` is `False`. This means that Bazel
+will create independent caches for each `maven_install` repository, located at
+`$(bazel info output_base)/external/@repository_name/v1`.
+
 ### Multiple `maven_install` declarations for isolated artifact version trees
 
 If your WORKSPACE contains several projects that use different versions of the

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,6 +29,7 @@ maven_install(
         "https://maven.google.com",
         "https://repo1.maven.org/maven2",
     ],
+    use_unsafe_shared_cache = True,
 )
 
 maven_install(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,7 +29,6 @@ maven_install(
         "https://maven.google.com",
         "https://repo1.maven.org/maven2",
     ],
-    use_unsafe_shared_cache = True,
 )
 
 maven_install(

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -306,6 +306,8 @@ def _coursier_fetch_impl(repository_ctx):
     cmd.extend(["--json-output-file", "dep-tree.json"])
     for repository in repositories:
         cmd.extend(["--repository", utils.repo_url(repository)])
+    if not repository_ctx.attr.use_unsafe_shared_cache:
+        cmd.extend(["--cache", "v1"]) # Download into $output_base/external/$maven_repo_name/v1
     if _is_windows(repository_ctx):
         # Unfortunately on Windows, coursier crashes while trying to acquire the
         # cache's .structure.lock file while running in parallel. This does not
@@ -334,6 +336,8 @@ def _coursier_fetch_impl(repository_ctx):
         cmd.extend(["--json-output-file", "src-dep-tree.json"])
         for repository in repositories:
             cmd.extend(["--repository", utils.repo_url(repository)])
+        if not repository_ctx.attr.use_unsafe_shared_cache:
+            cmd.extend(["--cache", "v1"]) # Download into $output_base/external/$maven_repo_name/v1
         exec_result = repository_ctx.execute(cmd)
         if (exec_result.return_code != 0):
             fail("Error while fetching artifact sources with coursier: "
@@ -369,6 +373,7 @@ coursier_fetch = repository_rule(
         "repositories": attr.string_list(),     # list of repository objects, each as json
         "artifacts": attr.string_list(),        # list of artifact objects, each as json
         "fetch_sources": attr.bool(default = False),
+        "use_unsafe_shared_cache": attr.bool(default = False),
         "_verify_checksums": attr.bool(default = False),
     },
     environ = ["JAVA_HOME"],

--- a/defs.bzl
+++ b/defs.bzl
@@ -20,7 +20,8 @@ def maven_install(
         name = REPOSITORY_NAME,
         repositories = [],
         artifacts = [],
-        fetch_sources = False):
+        fetch_sources = False,
+        use_unsafe_shared_cache = False):
 
     repositories_json_strings = []
     for repository in parse.parse_repository_spec_list(repositories):
@@ -35,6 +36,7 @@ def maven_install(
         repositories = repositories_json_strings,
         artifacts = artifacts_json_strings,
         fetch_sources = fetch_sources,
+        use_unsafe_shared_cache = use_unsafe_shared_cache,
     )
 
 def artifact(a, repository_name = REPOSITORY_NAME):
@@ -60,4 +62,3 @@ def _parse_artifact_str(artifact_str):
         return { "group": pieces[0], "artifact": pieces[1] }
     else:
         return parse.parse_maven_coordinate(artifact_str)
-


### PR DESCRIPTION
The default behavior of downloading artifacts into a shared $COURSIER_CACHE is potentially dangerous as Bazel is currently not capable of detecting cache poisoning events. 

This change adds the `use_unsafe_shared_cache` attribute to `maven_install`, which defaults to `False`. The default behavior creates independent coursier caches for each repository in `output_base/external/repo`. 

However, for performance reasons, we provide a switch to enable shared caches with a warning that it is unsafe.