### PR TITLE
Implement artifact exclusions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ script:
       export ANDROID_HOME=/usr/local/android-sdk
       bazel test //tests/unit/... && \
         ./tests/integration/simple_integration_test.sh
+        ./tests/integration/artifact_exclusions_integration_test.sh
     fi
 
 notifications:

--- a/README.md
+++ b/README.md
@@ -209,6 +209,40 @@ maven_install(
 )
 ```
 
+### Artifact exclusion
+
+If you want to exclude an artifact from the transitive closure of a top level
+artifact, specify its `group-id:artifact-id` in the `exclusions` attribute of
+the `maven.artifact` helper:
+
+```python
+load("@rules_maven//:defs.bzl", "artifact")
+load("@rules_maven//:specs.bzl", "maven")
+
+maven_install(
+    artifacts = [
+        maven.artifact(
+            group = "com.google.guava",
+            artifact = "guava",
+            version = "27.0-jre",
+            exclusions = [
+                maven.exclusion(
+                    group = "org.codehaus.mojo",
+                    artifact = "animal-sniffer-annotations"
+                ),
+                "com.google.j2objc:j2objc-annotations",
+            ]
+        ),
+        # ...
+    ],
+    repositories = [
+        # ...
+    ],
+)
+```
+
+You can specify the exclusion using either the `maven.exclusion` helper or the
+`group-id:artifact-id` string directly.
 
 ## How it works
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -60,7 +60,6 @@ maven_install(
     repositories = [
         "https://repo1.maven.org/maven2",
     ],
-    use_unsafe_shared_cache = True,
 )
 
 android_sdk_repository(name = "androidsdk")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,6 +5,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Begin test dependencies
 
 load("//:defs.bzl", "maven_install")
+load("//:specs.bzl", "maven")
 
 maven_install(
     artifacts = [
@@ -42,6 +43,26 @@ maven_install(
     ],
 )
 
+maven_install(
+    name = "other_maven_with_exclusions",
+    artifacts = [
+        maven.artifact(
+            group = "com.google.guava",
+            artifact = "guava",
+            version = "27.0-jre",
+            exclusions = [
+                maven.exclusion(group = "org.codehaus.mojo", artifact = "animal-sniffer-annotations"),
+                "com.google.j2objc:j2objc-annotations",
+            ]
+        ),
+    ],
+    fetch_sources = True,
+    repositories = [
+        "https://repo1.maven.org/maven2",
+    ],
+    use_unsafe_shared_cache = True,
+)
+
 android_sdk_repository(name = "androidsdk")
 
 BAZEL_SKYLIB_TAG = "0.6.0"
@@ -51,8 +72,5 @@ http_archive(
     strip_prefix = "bazel-skylib-%s" % BAZEL_SKYLIB_TAG,
     url = "https://github.com/bazelbuild/bazel-skylib/archive/%s.tar.gz" % BAZEL_SKYLIB_TAG,
 )
-
-# load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
-# bazel_skylib_workspace()
 
 # End test dependencies

--- a/specs.bzl
+++ b/specs.bzl
@@ -197,6 +197,14 @@ def _artifact_spec_to_json(artifact_spec):
     """
     maybe_exclusion_specs_jsons = []
     for exclusion_spec in artifact_spec.get("exclusions") or []:
+        if type(exclusion_spec) == "string":
+          pieces = exclusion_spec.split(":")
+          if len(pieces) == 2:
+              exclusion_spec = { "group": pieces[0], "artifact": pieces[1] }
+          else:
+              fail(("Invalid exclusion: %s. Exclusions are specified as " + \
+                   "group-id:artifact-id, without the version, packaging or " + \
+                   "classifier.") % exclusion_spec)
         maybe_exclusion_specs_jsons.append(_exclusion_spec_to_json(exclusion_spec))
     exclusion_specs_json = (("[" + ", ".join(maybe_exclusion_specs_jsons) + "]") if len(maybe_exclusion_specs_jsons) > 0 else None)
 

--- a/tests/integration/artifact_exclusions.golden
+++ b/tests/integration/artifact_exclusions.golden
@@ -1,0 +1,4 @@
+8a9
+> com_google_j2objc_j2objc_annotations
+9a11
+> org_codehaus_mojo_animal_sniffer_annotations

--- a/tests/integration/artifact_exclusions.golden
+++ b/tests/integration/artifact_exclusions.golden
@@ -1,4 +1,4 @@
-8a9
+5a6
 > com_google_j2objc_j2objc_annotations
-9a11
+8a10
 > org_codehaus_mojo_animal_sniffer_annotations

--- a/tests/integration/artifact_exclusions_integration_test.sh
+++ b/tests/integration/artifact_exclusions_integration_test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -eux
+set -o pipefail
+
+readonly SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+# try to run it once here to bootstrap
+$SCRIPT_DIR/../../third_party/coursier/coursier
+
+# Get list of inputs to the artifact library, which is a transitive exports of deps
+bazel query @other_maven//:com_google_guava_guava_lib --output=xml | grep "rule-input" | cut -d"\"" -f2 | cut -d":" -f2 > /tmp/without_exclusions.txt
+
+# Get list of inputs to the artifact library with excluded artifacts
+bazel query @other_maven_with_exclusions//:com_google_guava_guava_lib --output=xml | grep "rule-input" | cut -d"\"" -f2 | cut -d":" -f2 > /tmp/with_exclusions.txt
+
+# Get the diff between the two
+diff /tmp/with_exclusions.txt /tmp/without_exclusions.txt > /tmp/exclusion_diff.txt || true
+
+# Assert that the diff matches the two excluded artifacts
+diff /tmp/exclusion_diff.txt $SCRIPT_DIR/artifact_exclusions.golden

--- a/tests/integration/artifact_exclusions_integration_test.sh
+++ b/tests/integration/artifact_exclusions_integration_test.sh
@@ -23,7 +23,7 @@ bazel query @other_maven_with_exclusions//:com_google_guava_guava_lib --output=x
   | sort > /tmp/with_exclusions.txt
 
 # Get the diff between the two
-diff /tmp/with_exclusions.txt /tmp/without_exclusions.txt > /tmp/exclusion_diff.txt
+diff /tmp/with_exclusions.txt /tmp/without_exclusions.txt > /tmp/exclusion_diff.txt || true
 
 # Assert that the diff matches the two excluded artifacts
 diff /tmp/exclusion_diff.txt $SCRIPT_DIR/artifact_exclusions.golden

--- a/tests/integration/artifact_exclusions_integration_test.sh
+++ b/tests/integration/artifact_exclusions_integration_test.sh
@@ -9,13 +9,21 @@ readonly SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 $SCRIPT_DIR/../../third_party/coursier/coursier
 
 # Get list of inputs to the artifact library, which is a transitive exports of deps
-bazel query @other_maven//:com_google_guava_guava_lib --output=xml | grep "rule-input" | cut -d"\"" -f2 | cut -d":" -f2 > /tmp/without_exclusions.txt
+bazel query @other_maven//:com_google_guava_guava_lib --output=xml \
+  | grep "rule-input" \
+  | cut -d"\"" -f2 \
+  | cut -d":" -f2 \
+  | sort > /tmp/without_exclusions.txt
 
 # Get list of inputs to the artifact library with excluded artifacts
-bazel query @other_maven_with_exclusions//:com_google_guava_guava_lib --output=xml | grep "rule-input" | cut -d"\"" -f2 | cut -d":" -f2 > /tmp/with_exclusions.txt
+bazel query @other_maven_with_exclusions//:com_google_guava_guava_lib --output=xml \
+  | grep "rule-input" \
+  | cut -d"\"" -f2 \
+  | cut -d":" -f2 \
+  | sort > /tmp/with_exclusions.txt
 
 # Get the diff between the two
-diff /tmp/with_exclusions.txt /tmp/without_exclusions.txt > /tmp/exclusion_diff.txt || true
+diff /tmp/with_exclusions.txt /tmp/without_exclusions.txt > /tmp/exclusion_diff.txt
 
 # Assert that the diff matches the two excluded artifacts
 diff /tmp/exclusion_diff.txt $SCRIPT_DIR/artifact_exclusions.golden


### PR DESCRIPTION
This PR implements artifact exclusions using coursier's `--local-exclude-file` flag.

```python
load("@rules_maven//:defs.bzl", "artifact")
load("@rules_maven//:specs.bzl", "maven")
maven_install(
    artifacts = [
        maven.artifact(
            group = "com.google.guava",
            artifact = "guava",
            version = "27.0-jre",
            exclusions = [
                maven.exclusion(
                    group = "org.codehaus.mojo",
                    artifact = "animal-sniffer-annotations"
                ),
                "com.google.j2objc:j2objc-annotations",
            ]
        ),
        # ...
    ],
    repositories = [
        # ...
    ],
)
```
