### PR TITLE
(on hold) Add script to migrate from gmaven_rules

### DIFF
--- a/scripts/migrate_from_gmaven.sh
+++ b/scripts/migrate_from_gmaven.sh
@@ -15,7 +15,7 @@ find ./ -type f -name BUILD* -exec sed -i 's/gmaven_artifact(/maven_artifact(/g'
 find ./ -type f -name BUILD* -exec sed -i '/maven_artifact(/s/:aar//g; /maven_artifact(/s/:jar//g;' {} \;
 
 echo ""
-echo "Paste this into your WORKSPACE:"
+echo "Paste this into your WORKSPACE file:"
 echo "-------------------------"
 echo ""
 

--- a/scripts/migrate_from_gmaven.sh
+++ b/scripts/migrate_from_gmaven.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Replace the load statements
+find ./ -type f -name BUILD* -exec sed -i 's/gmaven_rules/rules_maven/g' {} \;
+
+# Replace the loaded gmaven_artifact symbol with maven_artifact
+find ./ -type f -name BUILD* -exec sed -i 's/"gmaven_artifact"/maven_artifact = "artifact"/g' {} \;
+
+# Replace the gmaven_artifact macro with maven_artifact
+find ./ -type f -name BUILD* -exec sed -i 's/gmaven_artifact(/maven_artifact(/g' {} \;
+
+# Remove the explicit packaging type from the coordinates
+find ./ -type f -name BUILD* -exec sed -i '/maven_artifact(/s/:aar//g; /maven_artifact(/s/:jar//g;' {} \;
+
+echo ""
+echo "Paste this into your WORKSPACE:"
+echo "-------------------------"
+echo ""
+
+cat <<-EOF
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+RULES_MAVEN_TAG = "0.1.4"
+RULES_MAVEN_SHA = ""
+
+http_archive(
+    name = "rules_maven",
+    strip_prefix = "rules_maven-%s" % RULES_MAVEN_TAG,
+    sha256 = RULES_MAVEN_SHA,
+    url = "https://github.com/jin/rules_maven/archive/%s.zip" % RULES_MAVEN_TAG,
+)
+
+load("@rules_maven//:defs.bzl", "maven_install")
+
+maven_install(
+    name = "maven",
+    artifacts = [
+EOF
+
+# Grep for all Maven artifact IDs and uniquify them.
+# Steps
+# 1. Get the list of maven_artifact declarations
+# 2. Remove the explicit packaging type
+# 3. Get the string to the left of the right bracket
+# 4. Get the string to the right of the left bracket
+# 5. Sort and de-duplicate
+# 6. Format for WORKSPACE
+find ./ -type f -name BUILD* -exec grep "maven_artifact(.*)" {} \; \
+  | sed -e "s/:aar//; s/:jar//" \
+  | cut -d')' -f1 \
+  | cut -d'(' -f2 \
+  | sort \
+  | uniq \
+  | sed 's/^/        /; s/$/,/;'
+
+cat <<-EOF
+    ],
+    repositories = [
+        "https://maven.google.com",
+        "https://repo1.maven.org/maven2",
+    ],
+)
+EOF
+
+echo ""
+echo "-------------------------"


### PR DESCRIPTION
This is written for Linux and tested on Linux. macOS and Windows versions coming soon.

Sample outputs:

For https://github.com/jin/android-projects

```python
Paste this into your WORKSPACE:
-------------------------

load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

RULES_MAVEN_TAG = "0.1.4"
RULES_MAVEN_SHA = ""

http_archive(
    name = "rules_maven",
    strip_prefix = "rules_maven-%s" % RULES_MAVEN_TAG,
    sha256 = RULES_MAVEN_SHA,
    url = "https://github.com/jin/rules_maven/archive/%s.zip" % RULES_MAVEN_TAG,
)

load("@rules_maven//:defs.bzl", "maven_install")

maven_install(
    name = "maven",
    artifacts = [
        "com.android.support:appcompat-v7:26.1.0",
        "com.android.support.constraint:constraint-layout:1.0.2",
        "com.android.support:multidex:1.0.1",
    ],
    repositories = [
        "https://maven.google.com",
        "https://repo1.maven.org/maven2",
    ],
)
```

Modified BUILD file:

```diff
diff --git a/androidAppModule3/BUILD.bazel b/androidAppModule3/BUILD.bazel
index 19c5362..901b13c 100644
--- a/androidAppModule3/BUILD.bazel
+++ b/androidAppModule3/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@gmaven_rules//:defs.bzl", "gmaven_artifact")
+load("@rules_maven//:defs.bzl", maven_artifact = "artifact")
 
 android_library(
     name = "androidAppModule3",
@@ -11,9 +11,9 @@ android_library(
         "//module0",
         "//module1",
         "//module2",
-        gmaven_artifact("com.android.support:appcompat-v7:aar:26.1.0"),
-        gmaven_artifact("com.android.support.constraint:constraint-layout:aar:1.0.2"),
-        gmaven_artifact("com.android.support:multidex:aar:1.0.1")
+        maven_artifact("com.android.support:appcompat-v7:26.1.0"),
+        maven_artifact("com.android.support.constraint:constraint-layout:1.0.2"),
+        maven_artifact("com.android.support:multidex:1.0.1")
     ],
 )
```

---

For https://github.com/googlesamples/android-testing


```python
Paste this into your WORKSPACE:
-------------------------

load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

RULES_MAVEN_TAG = "0.1.4"
RULES_MAVEN_SHA = ""

http_archive(
    name = "rules_maven",
    strip_prefix = "rules_maven-%s" % RULES_MAVEN_TAG,
    sha256 = RULES_MAVEN_SHA,
    url = "https://github.com/jin/rules_maven/archive/%s.zip" % RULES_MAVEN_TAG,
)

load("@rules_maven//:defs.bzl", "maven_install")

maven_install(
    name = "maven",
    artifacts = [
        "androidx.annotation:annotation:" + androidxLibVersion,
        "androidx.core:core:" + androidxLibVersion,
        "androidx.recyclerview:recyclerview:" + androidxLibVersion,
        "androidx.test:core:" + coreVersion,
        "androidx.test.espresso:espresso-contrib:" + espressoVersion,
        "androidx.test.espresso:espresso-core:" + espressoVersion,
        "androidx.test.espresso:espresso_idling_resource:" + espressoVersion,
        "androidx.test.espresso:espresso-idling-resource:" + espressoVersion,
        "androidx.test.espresso:espresso-intents:" + espressoVersion,
        "androidx.test.ext:junit:" + extJUnitVersion,
        "androidx.test.ext:truth:" + extTruthVersion,
        "androidx.test:monitor:" + runnerVersion,
        "androidx.test:rules:" + rulesVersion,
        "androidx.test:runner:" + runnerVersion,
        "androidx.test.uiautomator:uiautomator:" + uiAutomatorVersion,
    ],
    repositories = [
        "https://maven.google.com",
        "https://repo1.maven.org/maven2",
    ],
)
```

Modified BUILD file:


```diff
diff --git a/BUILD.bazel b/BUILD.bazel
index ab8fd35..fb12994 100644
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@gmaven_rules//:defs.bzl", "gmaven_artifact")
+load("@rules_maven//:defs.bzl", maven_artifact = "artifact")
 load("//:common_defs.bzl", "androidxLibVersion", "coreVersion", "espressoVersion", "extJUnitVersion", "extTruthVersion", "rulesVersion", "runnerVersion")
 
 licenses(["notice"])  # Apache 2.0
@@ -7,13 +7,13 @@ android_library(
     name = "test_deps",
     visibility = ["//visibility:public"],
     exports = [
-        gmaven_artifact("androidx.annotation:annotation:jar:" + androidxLibVersion),
-        gmaven_artifact("androidx.test.espresso:espresso-core:aar:" + espressoVersion),
-        gmaven_artifact("androidx.test:rules:aar:" + rulesVersion),
-        gmaven_artifact("androidx.test:runner:aar:" + runnerVersion),
-        gmaven_artifact("androidx.test:monitor:aar:" + runnerVersion),
-        gmaven_artifact("androidx.test.ext:junit:aar:" + extJUnitVersion),
-        gmaven_artifact("androidx.test:core:aar:" + coreVersion),
+        maven_artifact("androidx.annotation:annotation:" + androidxLibVersion),
+        maven_artifact("androidx.test.espresso:espresso-core:" + espressoVersion),
+        maven_artifact("androidx.test:rules:" + rulesVersion),
+        maven_artifact("androidx.test:runner:" + runnerVersion),
+        maven_artifact("androidx.test:monitor:" + runnerVersion),
+        maven_artifact("androidx.test.ext:junit:" + extJUnitVersion),
+        maven_artifact("androidx.test:core:" + coreVersion),
         "@com_google_guava_guava//jar",
         "@com_google_inject_guice//jar",
         "@javax_inject_javax_inject//jar",
diff --git a/ui/espresso/CustomMatcherSample/BUILD.bazel b/ui/espresso/CustomMatcherSample/BUILD.bazel
index dcb557a..92cfb6e 100644
--- a/ui/espresso/CustomMatcherSample/BUILD.bazel
+++ b/ui/espresso/CustomMatcherSample/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@gmaven_rules//:defs.bzl", "gmaven_artifact")
+load("@rules_maven//:defs.bzl", maven_artifact = "artifact")
 load("//:common_defs.bzl", "androidxLibVersion", "minSdkVersion", "targetSdkVersion")
 
 licenses(["notice"])  # Apache 2.0
@@ -10,7 +10,7 @@ android_library(
     manifest = "app/src/main/AndroidManifest.xml",
     resource_files = glob(["app/src/main/res/**/*"]),
     deps = [
-        gmaven_artifact("androidx.annotation:annotation:" + androidxLibVersion),
+        maven_artifact("androidx.annotation:annotation:" + androidxLibVersion),
         "@com_google_guava_guava//jar",
     ],
 )
```

---

For https://github.com/android/android-test

```python
Paste this into your WORKSPACE:
-------------------------

load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

RULES_MAVEN_TAG = "0.1.4"
RULES_MAVEN_SHA = ""

http_archive(
    name = "rules_maven",
    strip_prefix = "rules_maven-%s" % RULES_MAVEN_TAG,
    sha256 = RULES_MAVEN_SHA,
    url = "https://github.com/jin/rules_maven/archive/%s.zip" % RULES_MAVEN_TAG,
)

load("@rules_maven//:defs.bzl", "maven_install")

maven_install(
    name = "maven",
    artifacts = [
        "androidx.annotation:annotation:" + ANDROIDX_VERSION,
        "androidx.appcompat:appcompat:" + ANDROIDX_VERSION,
        "androidx.core:core:" + ANDROIDX_VERSION,
        "androidx.cursoradapter:cursoradapter:" + ANDROIDX_VERSION,
        "androidx.drawerlayout:drawerlayout:" + ANDROIDX_VERSION,
        "androidx.fragment:fragment:" + ANDROIDX_VERSION,
        "androidx.legacy:legacy-support-core-ui:" + ANDROIDX_VERSION,
        "androidx.legacy:legacy-support-core-utils:" + ANDROIDX_VERSION,
        "androidx.legacy:legacy-support-v4:" + ANDROIDX_VERSION,
        "androidx.lifecycle:lifecycle-common:" + ANDROIDX_LIFECYCLE_VERSION,
        "androidx.multidex:multidex:" + ANDROIDX_MULTIDEX_VERSION,
        "androidx.recyclerview:recyclerview:" + ANDROIDX_VERSION,
        "androidx.viewpager:viewpager:" + ANDROIDX_VERSION,
        "com.google.android.material:material:" + GOOGLE_MATERIAL_VERSION,
    ],
    repositories = [
        "https://maven.google.com",
        "https://repo1.maven.org/maven2",
    ],
)
```

Modified BUILD file:

```diff
$ git diff
diff --git a/BUILD.bazel b/BUILD.bazel
index 2d358ca..0b6792b 100644
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,7 +2,7 @@ package(default_visibility = ["//:__subpackages__"])
 
 load("//build_extensions:maven_repo.bzl", "maven_repository")
 load("//build_extensions:axt_versions.bzl", "ANDROIDX_VERSION", "ANDROIDX_LIFECYCLE_VERSION", "GOOGLE_MATERIAL_VERSION", "ANDROIDX_MULTIDEX_VERSION")
-load("@gmaven_rules//:defs.bzl", "gmaven_artifact")
+load("@rules_maven//:defs.bzl", maven_artifact = "artifact")
 
 exports_files([
     "proguard_binary.cfg",
@@ -56,70 +56,70 @@ alias(
 
 alias(
     name = "androidx_appcompat",
-    actual = gmaven_artifact("androidx.appcompat:appcompat:aar:" + ANDROIDX_VERSION),
+    actual = maven_artifact("androidx.appcompat:appcompat:" + ANDROIDX_VERSION),
 )
 
 alias(
     name = "google_android_material",
-    actual = gmaven_artifact("com.google.android.material:material:aar:" + GOOGLE_MATERIAL_VERSION),
+    actual = maven_artifact("com.google.android.material:material:" + GOOGLE_MATERIAL_VERSION),
 )
 
 alias(
     name = "androidx_multidex",
-    actual = gmaven_artifact("androidx.multidex:multidex:aar:" + ANDROIDX_MULTIDEX_VERSION),
+    actual = maven_artifact("androidx.multidex:multidex:" + ANDROIDX_MULTIDEX_VERSION),
 )

...

```