### PR TITLE
Actually use private cache with use_unsafe_shared_cache = False

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -62,6 +62,18 @@ maven_install(
     ],
 )
 
+maven_install(
+    name = "unsafe_shared_cache",
+    artifacts = [
+        "com.google.guava:guava:27.0-jre",
+    ],
+    fetch_sources = True,
+    repositories = [
+        "https://repo1.maven.org/maven2",
+    ],
+    use_unsafe_shared_cache = True,
+)
+
 android_sdk_repository(name = "androidsdk")
 
 BAZEL_SKYLIB_TAG = "0.6.0"

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -56,7 +56,7 @@ def _relativize_and_symlink_file(repository_ctx, absolute_path):
     else:
         # Make a symlink from the absolute path of the artifact to the relative
         # path within the output_base/external.
-        artifact_relative_path = absolute_path_parts[1]
+        artifact_relative_path = "v1/" + absolute_path_parts[1]
         repository_ctx.symlink(absolute_path, repository_ctx.path(artifact_relative_path))
     return artifact_relative_path
 

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -78,25 +78,30 @@ def generate_imports(repository_ctx, dep_tree, srcs_dep_tree = None):
     # seen_imports :: string -> bool
     seen_imports = {}
 
-    # First collect a map of target_label to their srcjar relative paths, and symlink the srcjars.
+    # First collect a map of target_label to their srcjar relative paths, and symlink the srcjars if needed.
     # We will use this map later while generating target declaration strings with the "srcjar" attr.
     srcjar_paths = None
     if srcs_dep_tree != None:
         srcjar_paths = {}
         for artifact in srcs_dep_tree["dependencies"]:
-            absolute_path_to_artifact = artifact["file"]
-            if absolute_path_to_artifact != None and absolute_path_to_artifact not in seen_imports:
-                seen_imports[absolute_path_to_artifact] = True
-                artifact_relative_path = _relativize_and_symlink_file(repository_ctx, absolute_path_to_artifact)
+            artifact_path = artifact["file"]
+            if artifact_path != None and artifact_path not in seen_imports:
+                seen_imports[artifact_path] = True
+                if repository_ctx.attr.use_unsafe_shared_cache:
+                  # If using unsafe shared cache, the path is absolute to the artifact in $COURSIER_CACHE
+                  artifact_relative_path = _relativize_and_symlink_file(repository_ctx, artifact_path)
+                else:
+                  # If not, it's a relative path to the one in output_base/external/$maven/v1/...
+                  artifact_relative_path = artifact_path
                 target_label = _escape(_strip_packaging_and_classifier(artifact["coord"]))
                 srcjar_paths[target_label] = artifact_relative_path
 
     # Iterate through the list of artifacts, and generate the target declaration strings.
     for artifact in dep_tree["dependencies"]:
-        absolute_path_to_artifact = artifact["file"]
+        artifact_path = artifact["file"]
         # Skip if we've seen this absolute path before.
-        if absolute_path_to_artifact not in seen_imports and absolute_path_to_artifact != None:
-            seen_imports[absolute_path_to_artifact] = True
+        if artifact_path not in seen_imports and artifact_path != None:
+            seen_imports[artifact_path] = True
 
             # We don't set the path of the artifact in resolved.bzl because it's different on everyone's machines
             checksums[artifact["coord"]] = {}
@@ -110,7 +115,12 @@ def generate_imports(repository_ctx, dep_tree, srcs_dep_tree = None):
                 ]).stdout
                 checksums[artifact["coord"]]["sha256"] = sha256
 
-            artifact_relative_path = _relativize_and_symlink_file(repository_ctx, absolute_path_to_artifact)
+            if repository_ctx.attr.use_unsafe_shared_cache:
+                # If using unsafe shared cache, the path is absolute to the artifact in $COURSIER_CACHE
+                artifact_relative_path = _relativize_and_symlink_file(repository_ctx, artifact_path)
+            else:
+                # If not, it's a relative path to the one in output_base/external/$maven/v1/...
+                artifact_relative_path = artifact_path
 
             # 1. Generate the rule class.
             #
@@ -225,7 +235,7 @@ java_library(
             all_imports.append(target_library.format(versionless_target_alias_label + "_lib", ",\n".join(transitive_dep_aliases)))
 
 
-        elif absolute_path_to_artifact == None:
+        elif artifact_path == None:
             fail("The artifact for " +
                  artifact["coord"] +
                  " was not downloaded. Perhaps the packaging type is not one of: jar, aar, bundle?\n" +

--- a/tests/integration/unsafe_shared_cache_integration_test.sh
+++ b/tests/integration/unsafe_shared_cache_integration_test.sh
@@ -11,10 +11,10 @@ $SCRIPT_DIR/../../third_party/coursier/coursier
 # tests for use_unsafe_shared_cache = True
 bazel fetch @unsafe_shared_cache//:all
 
-file $(bazel info output_base)/external/unsafe_shared_cache/https/repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar | grep "symbolic link to" \
+file $(bazel info output_base)/external/unsafe_shared_cache/v1/https/repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar | grep "symbolic link to" \
   || echo "Unsafe cache test failed for use_unsafe_shared_cache = True: guava-27.0-jre.jar is not a symbolic link"
 
-file $(bazel info output_base)/external/unsafe_shared_cache/https/repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre-sources.jar | grep "symbolic link to" \
+file $(bazel info output_base)/external/unsafe_shared_cache/v1/https/repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre-sources.jar | grep "symbolic link to" \
   || echo "Unsafe cache test failed for use_unsafe_shared_cache = True: guava-27.0-jre-sources.jar is not a symbolic link"
 
 # tests for use_unsafe_shared_cache = False

--- a/tests/integration/unsafe_shared_cache_integration_test.sh
+++ b/tests/integration/unsafe_shared_cache_integration_test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -eux
+set -o pipefail
+
+readonly SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+# try to run it once here to bootstrap
+$SCRIPT_DIR/../../third_party/coursier/coursier
+
+# tests for use_unsafe_shared_cache = True
+bazel fetch @unsafe_shared_cache//:all
+
+file $(bazel info output_base)/external/unsafe_shared_cache/https/repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar | grep "symbolic link to" \
+  || echo "Unsafe cache test failed for use_unsafe_shared_cache = True: guava-27.0-jre.jar is not a symbolic link"
+
+file $(bazel info output_base)/external/unsafe_shared_cache/https/repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre-sources.jar | grep "symbolic link to" \
+  || echo "Unsafe cache test failed for use_unsafe_shared_cache = True: guava-27.0-jre-sources.jar is not a symbolic link"
+
+# tests for use_unsafe_shared_cache = False
+bazel fetch @other_maven//:all
+
+file $(bazel info output_base)/external/other_maven/v1/https/repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre.jar | grep "Java archive data (JAR)" \
+  || echo "Unsafe cache test failed for use_unsafe_shared_cache = False: guava-27.0-jre.jar is not a JAR"
+
+file $(bazel info output_base)/external/other_maven/v1/https/repo1.maven.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre-sources.jar | grep "Zip archive data" \
+  || echo "Unsafe cache test failed for use_unsafe_shared_cache = False: guava-27.0-jre-sources.jar is not a Zip archive data"


### PR DESCRIPTION
Previously in https://github.com/jin/rules_maven/pull/12, we were only downloading the artifacts into output_base. The final generated BUILD was still referencing the shared cache artifact. It worked because I had a warm shared cache.

also add tests.