### PR TITLE
Remove the library() macro and _lib targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,35 @@ android_library(
 )
 ```
 
+The `artifact` macro translates the artifact's `group-id:artifact:id` to the
+label of the versionless target. This target is an
+[alias](https://docs.bazel.build/versions/master/be/general.html#alias) that
+points to the `java_import`/`aar_import` target in the `@maven` repository,
+which itself is wired up to dependencies specified in the artifact's POM file.
+
+For the `junit:junit` example, the following targets will be generated:
+
+```python
+alias(
+  name = "junit_junit",
+  actual = "@maven//:junit_junit_4_12",
+)
+
+java_import(
+  name = "junit_junit_4_12",
+  jars = ["@maven//:https/repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar"],
+  srcjar = "@maven//:https/repo1.maven.org/maven2/junit/junit/4.12/junit-4.12-sources.jar",
+  deps = ["@maven//:org_hamcrest_hamcrest_core_1_3"],
+)
+
+java_import(
+  name = "org_hamcrest_hamcrest_core_1_3",
+  jars = ["@maven//:https/repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"],
+  srcjar = "@maven//:https/repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar",
+  deps = [],
+)
+```
+
 ## Advanced usage
 
 ### Using a persistent artifact cache
@@ -259,15 +288,6 @@ The repository rule then..
    transitive library targets for each transitive artifact (including the top level 
    ones), and their respective deps matching the `<dependencies>` element in the 
    artifact's POM file.
-
-The `artifact` macro used in the BUILD file translates the artifact fully
-qualified name to the label of the top level `java_import`/`aar_import` target
-in the `@maven` repository. This macro will depend directly on the referenced jar, and
-nothing else. 
-
-The `library` macro accepts the same arguments, but references the `java_library` target
-for the arguments. The library target will contain the referenced jar *and* all of its
-transitive dependencies. 
 
 For example, the generated BUILD file for `com.google.inject:guice:4.0` looks like this:
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ The `artifact` macro translates the artifact's `group-id:artifact:id` to the
 label of the versionless target. This target is an
 [alias](https://docs.bazel.build/versions/master/be/general.html#alias) that
 points to the `java_import`/`aar_import` target in the `@maven` repository,
-which itself is wired up to dependencies specified in the artifact's POM file.
+which includes the transitive dependencies specified in the top level artifact's
+POM file.
 
 For the `junit:junit` example, the following targets will be generated:
 

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -220,12 +220,6 @@ def _deduplicate_list(items):
             unique_items.append(item)
     return unique_items
 
-def _find_dependency_by_coord(coursier_report, dep_coord):
-    for artifact in coursier_report["dependencies"]:
-        if artifact["coord"] == dep_coord:
-            return artifact
-    return None
-
 # Generate the base `coursier` command depending on the OS, JAVA_HOME or the
 # location of `java`.
 def _generate_coursier_command(repository_ctx):

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -203,38 +203,6 @@ def generate_imports(repository_ctx, dep_tree, srcs_dep_tree = None):
             versionless_target_alias_label = _escape(_strip_packaging_and_classifier_and_version(artifact["coord"]))
             all_imports.append("alias(\n\tname = \"%s\",\n\tactual = \"%s\",\n)" % (versionless_target_alias_label, target_label))
 
-            # 7. Create java_library rule (includes transitive dependencies)
-            #
-            # java_library(
-            #   name = "org_hamcrest_hamcrest_library_lib",
-            #   exports = [
-            #       ":org_hamcrest_hamcrest_core_1_3",
-            #       ":org_hamcrest_hamcrest_library_1_3",
-            #   ]
-            # )
-            transitive_dep_aliases = ["\t\t\":" + versionless_target_alias_label + "\""]
-            for transitive_dep_coord in artifact["dependencies"]:
-                transitive_dep = _find_dependency_by_coord(dep_tree, transitive_dep_coord)
-                if transitive_dep == None:
-                    fail("Could not find transitive dependency of " + artifact["coord"] + ": " + transitive_dep_coord + "\n" +
-                         "Parsed artifact data:" + repr(artifact) + "\n" +
-                         "Parsed dependency output:" + repr(dep_tree))
-
-                transitive_dep_aliases.append("\t\t\":" + _escape(_strip_packaging_and_classifier_and_version(transitive_dep["coord"])) + "\"")
-
-            target_library = \
-"""
-java_library(
-    name = "{}",
-    exports = [
-{}
-    ]
-)
-""".lstrip()
-            transitive_dep_aliases = _deduplicate_list(transitive_dep_aliases)
-            all_imports.append(target_library.format(versionless_target_alias_label + "_lib", ",\n".join(transitive_dep_aliases)))
-
-
         elif artifact_path == None:
             fail("The artifact for " +
                  artifact["coord"] +

--- a/defs.bzl
+++ b/defs.bzl
@@ -46,13 +46,6 @@ def artifact(a, repository_name = REPOSITORY_NAME):
 def maven_artifact(a):
     return artifact(a, repository_name = REPOSITORY_NAME)
 
-def library(a, repository_name = REPOSITORY_NAME):
-    artifact_obj = _parse_artifact_str(a) if type(a) == "string" else a
-    return "@%s//:%s" % (repository_name, _escape(artifact_obj["group"] + ":" + artifact_obj["artifact"] + "_lib"))
-
-def maven_library(a):
-    return library(a, repository_name = REPOSITORY_NAME)
-
 def _escape(string):
     return string.replace(".", "_").replace("-", "_").replace(":", "_")
 

--- a/tests/integration/artifact_exclusions.golden
+++ b/tests/integration/artifact_exclusions.golden
@@ -1,4 +1,4 @@
-5a6
-> com_google_j2objc_j2objc_annotations
-8a10
-> org_codehaus_mojo_animal_sniffer_annotations
+4a5
+> com_google_j2objc_j2objc_annotations_1_1
+9a11
+> org_codehaus_mojo_animal_sniffer_annotations_1_17

--- a/tests/integration/artifact_exclusions.golden
+++ b/tests/integration/artifact_exclusions.golden
@@ -1,4 +1,4 @@
 4a5
 > com_google_j2objc_j2objc_annotations_1_1
-9a11
+8a10
 > org_codehaus_mojo_animal_sniffer_annotations_1_17

--- a/tests/integration/artifact_exclusions.golden
+++ b/tests/integration/artifact_exclusions.golden
@@ -1,4 +1,0 @@
-7a8
-> com_google_j2objc_j2objc_annotations_1_1
-8a10
-> org_codehaus_mojo_animal_sniffer_annotations_1_17

--- a/tests/integration/artifact_exclusions.golden
+++ b/tests/integration/artifact_exclusions.golden
@@ -1,4 +1,4 @@
-4a5
+7a8
 > com_google_j2objc_j2objc_annotations_1_1
 8a10
 > org_codehaus_mojo_animal_sniffer_annotations_1_17

--- a/tests/integration/artifact_exclusions_integration_test.sh
+++ b/tests/integration/artifact_exclusions_integration_test.sh
@@ -14,15 +14,16 @@ bazel query @other_maven//:com_google_guava_guava_27_0_jre --output=xml \
   | cut -d"\"" -f2 \
   | cut -d":" -f2 > /tmp/without_exclusions.txt
 
+# Check that the artifacts are not excluded.
+grep "com_google_j2objc_j2objc_annotations_1_1" /tmp/without_exclusions.txt
+grep "org_codehaus_mojo_animal_sniffer_annotations_1_17" /tmp/without_exclusions.txt
+
 # Get list of inputs to the artifact library with excluded artifacts
 bazel query @other_maven_with_exclusions//:com_google_guava_guava_27_0_jre --output=xml \
   | grep "rule-input" \
   | cut -d"\"" -f2 \
   | cut -d":" -f2 > /tmp/with_exclusions.txt
 
-# Get the diff between the two
-diff /tmp/with_exclusions.txt /tmp/without_exclusions.txt > /tmp/exclusion_diff.txt || true
-
-# Assert that the diff matches the two excluded artifacts
-grep "com_google_j2objc_j2objc_annotations_1_1" /tmp/exclusion_diff.txt
-grep "org_codehaus_mojo_animal_sniffer_annotations_1_17" /tmp/exclusion_diff.txt
+# Check that the artifacts are excluded.
+grep -v "com_google_j2objc_j2objc_annotations_1_1" /tmp/with_exclusions.txt
+grep -v "org_codehaus_mojo_animal_sniffer_annotations_1_17" /tmp/with_exclusions.txt

--- a/tests/integration/artifact_exclusions_integration_test.sh
+++ b/tests/integration/artifact_exclusions_integration_test.sh
@@ -9,14 +9,14 @@ readonly SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 $SCRIPT_DIR/../../third_party/coursier/coursier
 
 # Get list of inputs to the artifact library, which is a transitive exports of deps
-bazel query @other_maven//:com_google_guava_guava_lib --output=xml \
+bazel query @other_maven//:com_google_guava_guava_27_0_jre --output=xml \
   | grep "rule-input" \
   | cut -d"\"" -f2 \
   | cut -d":" -f2 \
   | sort > /tmp/without_exclusions.txt
 
 # Get list of inputs to the artifact library with excluded artifacts
-bazel query @other_maven_with_exclusions//:com_google_guava_guava_lib --output=xml \
+bazel query @other_maven_with_exclusions//:com_google_guava_guava_27_0_jre --output=xml \
   | grep "rule-input" \
   | cut -d"\"" -f2 \
   | cut -d":" -f2 \

--- a/tests/integration/artifact_exclusions_integration_test.sh
+++ b/tests/integration/artifact_exclusions_integration_test.sh
@@ -10,17 +10,17 @@ $SCRIPT_DIR/../../third_party/coursier/coursier
 
 # Get list of inputs to the artifact library, which is a transitive exports of deps
 bazel query @other_maven//:com_google_guava_guava_27_0_jre --output=xml \
+  | sort \
   | grep "rule-input" \
   | cut -d"\"" -f2 \
-  | cut -d":" -f2 \
-  | sort > /tmp/without_exclusions.txt
+  | cut -d":" -f2 > /tmp/without_exclusions.txt
 
 # Get list of inputs to the artifact library with excluded artifacts
 bazel query @other_maven_with_exclusions//:com_google_guava_guava_27_0_jre --output=xml \
+  | sort \
   | grep "rule-input" \
   | cut -d"\"" -f2 \
-  | cut -d":" -f2 \
-  | sort > /tmp/with_exclusions.txt
+  | cut -d":" -f2 > /tmp/with_exclusions.txt
 
 # Get the diff between the two
 diff /tmp/with_exclusions.txt /tmp/without_exclusions.txt > /tmp/exclusion_diff.txt || true

--- a/tests/integration/artifact_exclusions_integration_test.sh
+++ b/tests/integration/artifact_exclusions_integration_test.sh
@@ -10,14 +10,12 @@ $SCRIPT_DIR/../../third_party/coursier/coursier
 
 # Get list of inputs to the artifact library, which is a transitive exports of deps
 bazel query @other_maven//:com_google_guava_guava_27_0_jre --output=xml \
-  | sort \
   | grep "rule-input" \
   | cut -d"\"" -f2 \
   | cut -d":" -f2 > /tmp/without_exclusions.txt
 
 # Get list of inputs to the artifact library with excluded artifacts
 bazel query @other_maven_with_exclusions//:com_google_guava_guava_27_0_jre --output=xml \
-  | sort \
   | grep "rule-input" \
   | cut -d"\"" -f2 \
   | cut -d":" -f2 > /tmp/with_exclusions.txt
@@ -26,4 +24,5 @@ bazel query @other_maven_with_exclusions//:com_google_guava_guava_27_0_jre --out
 diff /tmp/with_exclusions.txt /tmp/without_exclusions.txt > /tmp/exclusion_diff.txt || true
 
 # Assert that the diff matches the two excluded artifacts
-diff /tmp/exclusion_diff.txt $SCRIPT_DIR/artifact_exclusions.golden
+grep "com_google_j2objc_j2objc_annotations_1_1" /tmp/exclusion_diff.txt
+grep "org_codehaus_mojo_animal_sniffer_annotations_1_17" /tmp/exclusion_diff.txt


### PR DESCRIPTION
The original motivation for adding _lib targets for every artifact was to ensure that you don't need to specify transitive dependencies on top of the top level artifact in `deps` in order to use the top level artifact. This is already fully wired up in the versionless aliases and the `java_import` and `aar_import` targets.  

For example, if you want to use `junit:junit` which itself depends on `org.hamcrest:hamcrest-core`, you do not need to specify `artifact("org.hamcrest:hamcrest-core")` alongside `artifact("junit:junit")` in `deps`, because the `java_import` target for `junit:junit` already depends on `org:hamcrest:hamcrest-core`. 

The generated `_lib` targets, as it's implemented currently, re-exports the direct dependencies of an artifact, and itself, in a `java_library`. This may be useful to reduce the number of specified artifacts in `deps`, but it can hide unnecessary dependencies in the classpath, causing a large over-specification of available compile-time classes. If a target wishes to use an indirect dependency, the target should specify the versionless alias of the indirect dependency in its `deps`, and not rely on the overspecification of `_lib`/`library()` targets.